### PR TITLE
Add support for numpy ndarray objects

### DIFF
--- a/src/coredumpy/__init__.py
+++ b/src/coredumpy/__init__.py
@@ -13,7 +13,7 @@ from .pytest_hook import patch_pytest
 from .type_support import TypeSupportBase, TypeSupportContainerBase, NotReady
 from .unittest_hook import patch_unittest
 from .conf_hook import startup_conf
-from .types import builtin_types, torch_types  # noqa: F401
+from .types import builtin_types, torch_types, numpy_types  # noqa: F401
 
 startup_conf()
 

--- a/src/coredumpy/types/numpy_types.py
+++ b/src/coredumpy/types/numpy_types.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/gaogaotiantian/coredumpy/blob/master/NOTICE.txt
+
+import base64
+import io
+import sys
+
+from ..type_support import TypeSupportContainerBase
+
+
+class NumpyArraySupport(TypeSupportContainerBase):
+    @classmethod
+    def get_type(cls):
+        def lazy():
+            if sys.modules.get("numpy"):
+                import numpy
+
+                return numpy.ndarray
+            return None
+
+        return lazy, "numpy.ndarray"
+
+    @classmethod
+    def dump(cls, obj):
+        import numpy
+
+        buffer = io.BytesIO()
+        numpy.save(buffer, obj, allow_pickle=False)
+        return {
+            "type": "numpy.ndarray",
+            "value": base64.b64encode(buffer.getvalue()).decode(),
+        }, None
+
+    @classmethod
+    def load(cls, data, objects):
+        import numpy
+
+        buffer = io.BytesIO(base64.b64decode(data["value"]))
+        return numpy.load(buffer, allow_pickle=False), None
+
+    @classmethod
+    def reload(cls, container, data, objects):
+        assert False, "numpy.array should never be reloaded"  # pragma: no cover


### PR DESCRIPTION
### Summary

This PR adds native support for serializing and deserializing common NumPy ndarray in `coredumpy`, enabling smoother debugging and inspection for workloads that heavily rely on NumPy.

### What's included

- Support for `numpy.ndarray`

### Motivation

NumPy ndarray objects are extremely common in Python debugging scenarios, especially in ML and computer vision workloads. Without explicit support, they may be treated as opaque objects or lose important data. This PR adds native support to preserve NumPy arrays with full fidelity.
